### PR TITLE
Add post beta tasks

### DIFF
--- a/keps/sig-instrumentation/20191028-metrics-stability-to-beta.md
+++ b/keps/sig-instrumentation/20191028-metrics-stability-to-beta.md
@@ -12,7 +12,7 @@ approvers:
   - "@brancz"
 editor: "@brancz"
 creation-date: 2019-10-28
-last-updated: 2019-10-28
+last-updated: 2019-11-01
 status: implementable
 see-also:
   - 20181106-kubernetes-metrics-overhaul
@@ -78,9 +78,10 @@ There are still open questions that need to be addressed and updated in this KEP
 
 ## Post-Beta tasks
 
-These are related Post-GA tasks:
+These are related Post-Beta tasks:
 
-*
+* Turn off individual metric(should not require a new release of kubernetes in order to turn off a bad metric).
+* Introduce other functionality to stability framework if need be.(e.g. UntypedFunc, CounterFunc)
 
 ## Implementation History
 


### PR DESCRIPTION
I guess post-beta tasks means the tasks that can be started after beta.

I also have thought if we should filter metrics from an endpoint.
E.g. now, if we get metrics by `curl localhost:10255/metrics`, all metrics will be shown out.

If there is a scenario that user just wants some specific metrics?  
E.g.  `curl localhost:10255/metrics/metrics_1&metrics_2` . in this case ,only metrics_1 and metrics_2 will be shown.